### PR TITLE
Bump Alpine to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN make build
 RUN wget -O /usr/bin/yt-dlp https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp && \
     chmod +x /usr/bin/yt-dlp
 
-FROM alpine:3.17
+# Alpine 3.21 will go EOL on 2026-11-01
+FROM alpine:3.21
 
 WORKDIR /app
 


### PR DESCRIPTION
Alpine 3.17 went EOL 2024-11-22
Relevant changes:
ffmpeg 5.1.4-r0 -> 6.1.2-r1
python3 3.10.15-r0 -> 3.12.9-r0
libc6-compat 1.2.3-r6 -> gcompat 1.1.0-r4